### PR TITLE
add plugins/heptio-authenticator-aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ place for people (and asdf itself) to look for plugins.
 | Gradle    | [rfrancis/asdf-gradle](https://github.com/rfrancis/asdf-gradle) | [![Build Status](https://travis-ci.org/rfrancis/asdf-gradle.svg?branch=master)](https://travis-ci.org/rfrancis/asdf-gradle)
 | Haskell   | [vic/asdf-haskell](https://github.com/vic/asdf-haskell) | [![Build Status](https://travis-ci.org/vic/asdf-haskell.svg?branch=master)](https://travis-ci.org/vic/asdf-haskell)
 | Helm      | [Antiarchitect/asdf-helm](https://github.com/Antiarchitect/asdf-helm) | [![Build Status](https://travis-ci.org/Antiarchitect/asdf-helm.svg?branch=master)](https://travis-ci.org/Antiarchitect/asdf-helm)
+| heptio-authenticator-aws | [neerfri/asdf-heptio-authenticator-aws](https://github.com/neerfri/asdf-heptio-authenticator-aws) | [![Build Status](https://travis-ci.org/neerfri/asdf-heptio-authenticator-aws.svg?branch=master)](https://travis-ci.org/neerfri/asdf-heptio-authenticator-aws)
 | Idris     | [vic/asdf-idris](https://github.com/vic/asdf-idris) | [![Build Status](https://travis-ci.org/vic/asdf-idris.svg?branch=master)](https://travis-ci.org/vic/asdf-idris)
 | ImageMagick     | [mangalakader/asdf-imagemagick](https://github.com/mangalakader/asdf-imagemagick) | [![Build Status](https://travis-ci.org/mangalakader/asdf-imagemagick.svg?branch=master)](https://travis-ci.org/mangalakader/asdf-imagemagick)
 | Jsonnet   | [Banno/asdf-jsonnet](https://github.com/Banno/asdf-jsonnet) | [![Build Status](https://travis-ci.org/Banno/asdf-jsonnet.svg?branch=master)](https://travis-ci.org/Banno/asdf-jsonnet)

--- a/plugins/heptio-authenticator-aws
+++ b/plugins/heptio-authenticator-aws
@@ -1,0 +1,1 @@
+repository = https://github.com/neerfri/asdf-heptio-authenticator-aws


### PR DESCRIPTION
Adding a plugin for [heptio-authenticator-aws](https://github.com/heptio/authenticator)